### PR TITLE
Enable start/stop ADX with multiple clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ All functions in the same function app share resources, per instance, as the fun
         * `0 0 19 * * 1-5` for Monday to Friday at 8:00pm GMT+1 (Paris winter time)
 * From VSCode Azure Extension, deploy the code to the Azure Function App you just created before
 * In Azure Portal > Function App > Configuration, add the following environment vairables:
-    * ADX_CLUSTER_NAME
-    * ADX_RESOURCE_GROUP
+    * ADX_CLUSTERS_CONFIG (example : [{"cluster_name": "cluster1", "resource_group": "group1"}, {"cluster_name": "cluster2", "resource_group": "group2"}, ...])
     * AKS_CLUSTER_NAME
     * AKS_RESOURCE_GROUP
     * AZURE_SUBSCRIPTION_ID

--- a/StartAdxCluster/__init__.py
+++ b/StartAdxCluster/__init__.py
@@ -9,19 +9,23 @@ from azure.mgmt.kusto import KustoManagementClient
 def main(startadxtimer: func.TimerRequest) -> None:
 
     SUBSCRIPTION_ID = os.environ["AZURE_SUBSCRIPTION_ID"]
-    ADX_RESOURCE_GROUP = os.environ["ADX_RESOURCE_GROUP"]
-    ADX_CLUSTER_NAME = os.environ["ADX_CLUSTER_NAME"]
+    ADX_CLUSTERS_CONFIG = json.loads(os.environ["ADX_CLUSTERS_CONFIG"])
+    # ADX_CLUSTERS_CONFIG=[{"cluster_name": "cluster1", "resource_group": "group1"}, {"cluster_name": "cluster2", "resource_group": "group2"}, ...]
 
     client = KustoManagementClient(credential=DefaultAzureCredential(), subscription_id=SUBSCRIPTION_ID)
 
     utc_timestamp = datetime.datetime.utcnow().replace(
         tzinfo=datetime.timezone.utc).isoformat()
     
-    poller = client.clusters.begin_start(
-        resource_group_name=ADX_RESOURCE_GROUP,
-        cluster_name=ADX_CLUSTER_NAME,
-    )
-    if poller.done():
-        logging.info(f"Started Kusto Cluster {ADX_CLUSTER_NAME}: {ADX_RESOURCE_GROUP}...")
+    for cluster_config in ADX_CLUSTERS_CONFIG:
+        resource_group = cluster_config['resource_group']
+        cluster_name = cluster_config['cluster_name']
+        
+        poller = client.clusters.begin_start(
+            resource_group_name=resource_group,
+            cluster_name=cluster_name,
+        )
+        if poller.done():
+            logging.info(f"Started Kusto Cluster {cluster_name} in {resource_group}...")
 
-    logging.info(f"Python timer trigger function ran {utc_timestamp}")
+    logging.info(f"Python timer trigger function ran at {utc_timestamp}")

--- a/StopAdxCluster/__init__.py
+++ b/StopAdxCluster/__init__.py
@@ -9,19 +9,23 @@ from azure.mgmt.kusto import KustoManagementClient
 def main(stopadxtimer: func.TimerRequest) -> None:
 
     SUBSCRIPTION_ID = os.environ["AZURE_SUBSCRIPTION_ID"]
-    ADX_RESOURCE_GROUP = os.environ["ADX_RESOURCE_GROUP"]
-    ADX_CLUSTER_NAME = os.environ["ADX_CLUSTER_NAME"]
+    ADX_CLUSTERS_CONFIG = json.loads(os.environ["ADX_CLUSTERS_CONFIG"])
+    # ADX_CLUSTERS_CONFIG=[{"cluster_name": "cluster1", "resource_group": "group1"}, {"cluster_name": "cluster2", "resource_group": "group2"}, ...]
 
     client = KustoManagementClient(credential=DefaultAzureCredential(), subscription_id=SUBSCRIPTION_ID)
     
     utc_timestamp = datetime.datetime.utcnow().replace(
         tzinfo=datetime.timezone.utc).isoformat()
 
-    poller = client.clusters.begin_stop(
-        resource_group_name=ADX_RESOURCE_GROUP,
-        cluster_name=ADX_CLUSTER_NAME,
-    )
-    if poller.done():
-        logging.info(f"Stopped Kusto Cluster {ADX_CLUSTER_NAME}: {ADX_RESOURCE_GROUP}...")
+    for cluster_config in ADX_CLUSTERS_CONFIG:
+        resource_group = cluster_config['resource_group']
+        cluster_name = cluster_config['cluster_name']
+        
+        poller = client.clusters.begin_stop(
+            resource_group_name=resource_group,
+            cluster_name=cluster_name,
+        )
+        if poller.done():
+            logging.info(f"Stopped Kusto Cluster {cluster_name} in {resource_group}...")
 
-    logging.info(f"Python timer trigger function ran {utc_timestamp}")
+    logging.info(f"Python timer trigger function ran at {utc_timestamp}")


### PR DESCRIPTION
Enable starting and stopping ADX with multiple clusters.

Removed ADX_RESOURCE_GROUP and ADX_CLUSTER_NAME env vars, replaced with ADX_CLUSTERS_CONFIG which links ADX cluster to its resource group.

Example : [{"cluster_name": "cluster1", "resource_group": "group1"}, {"cluster_name": "cluster2", "resource_group": "group2"}, ...]